### PR TITLE
Fix default value assignment for Verb in Command struct

### DIFF
--- a/Source/Gorgon/CGI/Path.h
+++ b/Source/Gorgon/CGI/Path.h
@@ -29,7 +29,7 @@ public:
 
   /// Single drawing command stored in the path.
   struct Command {
-    Verb Verb = Close;
+    Verb Verb = Verb::Close;
 
     union {
       Point To;


### PR DESCRIPTION
This pull request contains a minor fix to the default initialization of the `Verb` member in the `Command` struct within `Source/Gorgon/CGI/Path.h`. The change ensures that the `Verb` is explicitly initialized with the `Verb::Close` enumerator, which improves code clarity and correctness.

- Code quality improvement:
  * Updated the default initialization of the `Verb` member in the `Command` struct to use `Verb::Close` instead of a plain `Close` value, clarifying the enum scope.