### PR TITLE
Enhance basic_Path with new commands and improve installation handling

### DIFF
--- a/Source/Gorgon/Scripting/CMakeLists.txt
+++ b/Source/Gorgon/Scripting/CMakeLists.txt
@@ -5,7 +5,6 @@ target_sources(Gorgon
     FILES
 		../Scripting.h
 		Data.h
-		Exceptions.h
 		Embedding.h
 		Input.h
 		Instruction.h


### PR DESCRIPTION
This pull request significantly enhances the `basic_Path` class in `Path.h` by adding support for quadratic Bezier and SVG elliptical arc segments, including their storage, construction, flattening, and iteration. It also makes several CMake improvements for dependency handling and installation, and adds a missing header to the scripting sources.

**Path segment support and rendering improvements:**

* Added support for quadratic Bezier (`QuadraticTo`) and SVG elliptical arc (`ArcTo`) segments to the `basic_Path` class, including new command types, data structures (`Quadratic`, `Arc`), and methods for appending these segments (`AddQuadraticTo`, `AddArcTo`). [[1]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afL20-R27) [[2]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afR36-R54) [[3]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afR75-R82) [[4]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afR91-R99) [[5]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afR149-R170)
* Implemented flattening logic for quadratic and arc segments, converting them into polylines for rasterization or further processing. This includes the `AppendArcAsPolyline` helper and associated math for arc-to-bezier conversion. [[1]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afR240-R260) [[2]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afR278-R283) [[3]](diffhunk://#diff-ebc8036cd60e29eacf0f572dfefe2f9d14b2e2f891dce25d62bc6db9904e52afR395-R523)
* Updated iteration and access methods to handle the new segment types and provide read-only access to commands and contours.

**Build system and dependency improvements:**

* Improved FLAC dependency handling in `GorgonConfig.cmake.in` to use `pkg_check_modules` on non-Windows platforms, ensuring proper discovery in different environments.
* Modified `Install.cmake` to copy `Public.cmake` to the build directory during export, improving CMake configuration for consumers.

**Other changes:**

* Added the missing `Exceptions.h` header to the scripting CMake sources.
* Included `<cmath>` for mathematical operations required by arcs in `Path.h`.